### PR TITLE
Fix QA Webapp Link Bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.4] - 2023-12-07
+
+### Fixed
+ - Fixed bug in QA webapp where the next session link would take you to the subject page
+
 ## [1.0.3] - 2023-12-05
 
 ### Added

--- a/radifox/qa/templates/conversion.html
+++ b/radifox/qa/templates/conversion.html
@@ -297,14 +297,14 @@
 <nav class="navbar fixed-bottom navbar-dark bg-dark" style="padding-top: 0; padding-bottom: 0">
     <span class="navbar-text">
         {% if prev_session %}
-            &larr;&nbsp;&nbsp;<a href="{{ url_for('qa_page', project_id=project_id, subject_id=subject_id, session_id=prev_scan) }}">{{ prev_session }}</a>
+            &larr;&nbsp;&nbsp;<a href="{{ url_for('qa_page', project_id=project_id, subject_id=subject_id, session_id=prev_session) }}">{{ prev_session }}</a>
         {% elif prev_subject %}
             &larr;&nbsp;&nbsp;<a href="{{ url_for('subject', project_id=project_id, subject_id=prev_subject) }}">{{ prev_subject }}</a>
         {% endif %}
     </span>
     <span class="navbar-text">
         {% if next_session %}
-            <a href="{{ url_for('qa_page', project_id=project_id, subject_id=subject_id, session_id=next_scan) }}">{{ next_session }}</a>&nbsp;&nbsp;&rarr;
+            <a href="{{ url_for('qa_page', project_id=project_id, subject_id=subject_id, session_id=next_session) }}">{{ next_session }}</a>&nbsp;&nbsp;&rarr;
         {% elif next_subject %}
             <a href="{{ url_for('subject', project_id=project_id, subject_id=next_subject) }}">{{ next_subject }}</a>&nbsp;&nbsp;&rarr;
         {% endif %}


### PR DESCRIPTION
Fixes a bug in the QA Webapp where the "next session" link at the bottom of the page takes you to the current subject page instead.