### PR TITLE
Fix staging for missing image files

### DIFF
--- a/radifox/conversion/base.py
+++ b/radifox/conversion/base.py
@@ -194,7 +194,7 @@ class BaseInfo:
             resolution = "3D" if "3d" in series_desc else "2D"
         # 3) Ex-contrast
         excontrast = "PRE"
-        if not (self.ExContrastAgent is None or self.ExContrastAgent == ""):
+        if not (self.ExContrastAgent is None or self.ExContrastAgent.upper() in ["", "NONE"]):
             excontrast = "POST"
         elif any([item in series_desc for item in POSTGAD_DESC]) and "pre" not in series_desc:
             excontrast = "POST"

--- a/radifox/modules/staging.py
+++ b/radifox/modules/staging.py
@@ -69,7 +69,8 @@ class Staging(ProcessingModule):
             all_imgs = glob(session / "nii" / "*.nii.gz")
             all_imgs = sorted(all_imgs, key=lambda x: x.name, reverse=True)
             all_imgs = [img for img in all_imgs if "ND" not in img.extras]
-            session_imgs[session] = all_imgs
+            if all_imgs:
+                session_imgs[session] = all_imgs
 
         return {
             "session_filepaths": list(session_imgs.values()),

--- a/radifox/modules/staging.py
+++ b/radifox/modules/staging.py
@@ -69,8 +69,6 @@ class Staging(ProcessingModule):
             all_imgs = glob(session / "nii" / "*.nii.gz")
             all_imgs = sorted(all_imgs, key=lambda x: x.name, reverse=True)
             all_imgs = [img for img in all_imgs if "ND" not in img.extras]
-            if not all_imgs:
-                parser.error(f"No images found in {session}")
             session_imgs[session] = all_imgs
 
         return {
@@ -110,6 +108,8 @@ class Staging(ProcessingModule):
             skip_default_plugins,
             skip_set_sform,
         ):
+            if not all_imgs:
+                continue
             # Create "stage" directory
             session = all_imgs[0].parent.parent
             (session / "stage").mkdir(exist_ok=True, parents=True)
@@ -229,8 +229,8 @@ class Staging(ProcessingModule):
         return [
             {
                 "staged_files": imgs,
-                "session_target": session_targets[session],
-                "subject_target": subject_target,
+                "session_target": session_targets[session] if session in session_targets else None,
+                "subject_target": subject_target if session in session_targets else None,
             }
             for session, imgs in session_imgs.items()
         ]

--- a/radifox/records/processing.py
+++ b/radifox/records/processing.py
@@ -239,7 +239,7 @@ class ProcessingModule(ABC):
         out_dir = out.parent.parent / "qa" / name
         out_dir.mkdir(exist_ok=True, parents=True)
         for out in outs:
-            if out is None or not out.name.endswith(".nii.gz"):
+            if out is None:
                 continue
             if isinstance(out, tuple):
                 overlay = out[0]

--- a/radifox/records/processing.py
+++ b/radifox/records/processing.py
@@ -145,7 +145,7 @@ class ProcessingModule(ABC):
         return prov_str
 
     @staticmethod
-    def get_prov_path_strs(path_dict: dict[str, Path | list[Path]], project_root: Path) -> str:
+    def get_prov_path_strs(path_dict: dict[str, Path | list[Path] | None], project_root: Path) -> str:
         prov_str = ""
         for k, v in path_dict.items():
             if v is None:
@@ -171,7 +171,7 @@ class ProcessingModule(ABC):
     @staticmethod
     def write_prov(
         prov_str: str,
-        outputs: dict[str, Path | list[Path]],
+        outputs: dict[str, Path | list[Path] | None],
         skip_prov_write: tuple[str],
     ) -> None:
         outs = [
@@ -180,13 +180,19 @@ class ProcessingModule(ABC):
             if key not in skip_prov_write
             for el in (sub if isinstance(sub, list) else [sub])
         ]
-        for j, output in enumerate(outs):
-            if j == 0:
+        if len(outs) == 0:
+            return
+        first = True
+        for output in outs:
+            if output is None:
+                continue
+            if first:
                 session_dir = output.parent.parent
                 session_file = "_".join(
                     [session_dir.parent.name, session_dir.name, "Provenance.yml"]
                 )
                 safe_append_to_file(session_dir / session_file, prov_str)
+                first = False
             suffix = "".join(output.suffixes)
             prov_path = output.parent / output.name.replace(suffix, ".prov")
             with open(prov_path, "w") as f:
@@ -217,7 +223,7 @@ class ProcessingModule(ABC):
 
     @staticmethod
     def create_qa(
-        outputs: dict[str, Path | list[Path]],
+        outputs: dict[str, Path | list[Path] | None],
         name: str,
         skip_prov_write: tuple[str],
     ) -> None:
@@ -227,10 +233,14 @@ class ProcessingModule(ABC):
             if key not in skip_prov_write
             for el in (sub if isinstance(sub, list) else [sub])
         ]
+        if len(outs) == 0:
+            return
         out = outs[0][0] if isinstance(outs[0], tuple) else outs[0]
         out_dir = out.parent.parent / "qa" / name
         out_dir.mkdir(exist_ok=True, parents=True)
         for out in outs:
+            if out is None or not out.name.endswith(".nii.gz"):
+                continue
             if isinstance(out, tuple):
                 overlay = out[0]
                 bg_image = out[1]


### PR DESCRIPTION
Fixes staging for sessions without any filtered images (or any images at all). Sessions without images will be skipped altogether. 

Additional bug fixes:
- ProcessingModule API now allows non-image outputs (still a `Path` object or `None`)
- Allow "NONE" as a contrast string for pre-gad imaging