### PR TITLE
Fix for permissions and MF dicom files

### DIFF
--- a/radifox/conversion/dicom.py
+++ b/radifox/conversion/dicom.py
@@ -269,7 +269,7 @@ def sort_dicoms(dcm_dir: Path, force_dicom: bool = False) -> None:
     # Find new series that have scans that share DICOM files (multi-frame)
     uids_by_files = defaultdict(list)
     for scan, dcm_list in dicom_sort_dict.items():
-        uids_by_files[tuple(dcm[0] for dcm in dcm_list)].append(scan)
+        uids_by_files[tuple(sorted(set(dcm[0] for dcm in dcm_list)))].append(scan)
     # Merge new series uids that share DICOM files
     for scans in uids_by_files.values():
         if len(scans) > 1:

--- a/radifox/conversion/exec.py
+++ b/radifox/conversion/exec.py
@@ -80,12 +80,12 @@ def run_conversion(
                     logging.info("Linking files from source to %s folder" % type_folder.name)
                     if link not in ["symlink", "hardlink"]:
                         raise ValueError("Unsupported linking type.")
-                    copytree_link(source, type_folder, link == "symlink")
+                    copytree_link(source, type_folder, link)
                     logging.info("Linking complete")
                 else:
                     logging.info("Copying files from source to %s folder" % type_folder.name)
                     # noinspection PyTypeChecker
-                    shutil.copytree(source, type_folder, copy_function=shutil.copyfile)
+                    copytree_link(source, type_folder, "copy")
                     logging.info("Copying complete")
             elif any([source.name.endswith(ext) for ext in allowed_archives()[1]]):
                 extract_archive(source, type_folder)


### PR DESCRIPTION
Two bug fixes.

1) Avoids bringing in permissions from the source directories.
2) Fixes an issue where multi-frame dicoms might have different number of headers. this is uncommon but the solution makes sense.