### PR TITLE
Add support/buttons for QA result logging

### DIFF
--- a/radifox/qa/templates/conversion.html
+++ b/radifox/qa/templates/conversion.html
@@ -109,7 +109,7 @@
                 <div class="col-5">
                     {% if item.manual_name != '' %}
                         <h4 class="{% if item.created_by == 'MODIFIED' %}negative{% else %}neutral{% endif %}">
-                            Manual: {{ item.manual_name }}
+                            {% if item.created_by == 'LOOKUP' %}Lookup{% else %}Manual{% endif %}: {{ item.manual_name }}
                         </h4>
                     {% endif %}
                 </div>

--- a/radifox/qa/templates/login.html
+++ b/radifox/qa/templates/login.html
@@ -62,7 +62,9 @@
                     </div>
                 {% endif %}
                 <form method="POST" action="{{ url_for('login') }}">
-                    Key: <input type="password" name="key" class="form-control">
+                    User: <input type="text" name="user" value="{{ user }}" class="form-control">
+                    <br />
+                    Key: <input type="password" name="key" value="{{ key }}" class="form-control">
                     <br>
                     <input type="submit" value="Login" class="btn btn-primary">
                 </form>

--- a/radifox/qa/templates/processing.html
+++ b/radifox/qa/templates/processing.html
@@ -47,14 +47,6 @@
             justify-content: right;
             align-items: center;
         }
-
-        .negative {
-            color: red;
-        }
-
-        .neutral {
-            color: black;
-        }
     </style>
     <title>RADIFOX QA - {{ subject_id }}&nbsp;/&nbsp;{{ session_id }}</title>
 </head>
@@ -83,19 +75,52 @@
 <br />
 <div class="container-fluid">
     {% for key, value in processing_results|items %}
+        {% set steploop = loop %}
         <h2 class="text-center">{{ key | upper() | replace(':', ' v') }}</h2>
         <hr /><hr />
         <br />
         {% for id, prov in value|items %}
+            {% set provloop = loop %}
             {% for output_name, qa_dict in prov.OutputQA|items %}
+                {% set outloop = loop %}
                 <div class="container-fluid">
                     <div class="row"><div class="col">
                         <h4>{{ output_name|replace('_',' ')|title() }}:</h4>
                     </div></div>
                     <div class="row"><div class="col">
                         {% for filestr, qa_img in qa_dict|items %}
-                            <div class="container-fluid outer-container" id="image{{ loop.index }}">
-                                <div class="row"><div class="col"><h5>{{ filestr }}</h5></div></div>
+                            {% set imgloop = loop %}
+                            <div class="container-fluid outer-container" id="image{{ steploop.index }}-{{ provloop.index }}-{{ outloop.index }}-{{ imgloop.index }}">
+                                <div class="row">
+                                    <div class="col-10"><h5>{{ qa_img[3] }}</h5></div>
+                                    <div class="col-2 right-button">
+                                        <button type="button"
+                                                onclick="sendPostRequest(this)"
+                                                data-api="qa-pass"
+                                                data-project="{{ project_id }}"
+                                                data-subject="{{ subject_id }}"
+                                                data-session="{{ session_id }}"
+                                                data-source_path="{{ filestr }}"
+                                                data-loop_index="{{ steploop.index }}-{{ provloop.index }}-{{ outloop.index }}-{{ imgloop.index }}"
+                                                id="qa-pass{{ steploop.index }}-{{ provloop.index }}-{{ outloop.index }}-{{ imgloop.index }}"
+                                                class="btn {% if qa_img[4] == "pass" %}btn-success{% else %}btn-dark{% endif %}">
+                                            PASS
+                                        </button>
+                                        &nbsp;
+                                        <button type="button"
+                                                onclick="sendPostRequest(this)"
+                                                data-api="qa-fail"
+                                                data-project="{{ project_id }}"
+                                                data-subject="{{ subject_id }}"
+                                                data-session="{{ session_id }}"
+                                                data-source_path="{{ filestr }}"
+                                                data-loop_index="{{ steploop.index }}-{{ provloop.index }}-{{ outloop.index }}-{{ imgloop.index }}"
+                                                id="qa-fail{{ steploop.index }}-{{ provloop.index }}-{{ outloop.index }}-{{ imgloop.index }}"
+                                                class="btn {% if qa_img[4] == "fail" %}btn-danger{% else %}btn-dark{% endif %}">
+                                            FAIL
+                                        </button>
+                                    </div>
+                                </div>
                             {% if qa_img %}
                                 <div class="row border-10 border-secondary mx-auto" style="background:#000000; width: 100%">
                                     <div class="col text-center">
@@ -110,113 +135,17 @@
                     </div></div>
                 </div>
             {% endfor %}
-            <div class="container-fluid" id="image{{ prov.OutputQA|length }}">
-               <br/>
-                <div class="row">
-                    <div class="col">
-                        <h5 class="text-center"><span class="font-weight-bold">ID: </span>{{ prov.Id }}</h5>
-                    </div>
-                </div>
-                <div class="row">
-                    <div class="col">
-                        <h5 class="text-left">
-                            <span class="font-weight-bold">Container:</span>
-                            <br/>
-                            {{ prov.Container.url }}
-                            <br />
-                            {{ prov.Container.hash }}
-                            <br />
-                            Built: {{ prov.Container.timestamp.strftime('%Y-%m-%d %H:%M:%S') }} by {{ prov.Container.builder }}
-                        </h5>
-                    </div>
-                    <div class="col">
-                        <h5 class="text-right">
-                            <span class="font-weight-bold">Run Info:</span>
-                            <br/>
-                            Started: {{ prov.StartTime }}
-                            <br />
-                            Duration: {{ prov.Duration }}
-                            <br />
-                            User: {{ prov.User }}
-                        </h5>
-                    </div>
-                </div>
-                <div class="row">
-                    <div class="col">
-                        <h5 class="text-left">
-                            <span class="font-weight-bold">Inputs:</span>
-                            <br/>
-                            {% for key, value in prov.Inputs|items %}
-                                {% if value is iterable and value is not string %}
-                                    {{ key }}: <br />
-                                    {% for sub in value %}
-                                        {% set val = sub.split(':') %}
-                                        &emsp; - {{ val[0] }}<br />
-                                        <span class="text-muted">&emsp;&emsp;[{{ val[1] }}:{{ val[2] }}]</span><br />
-                                    {% endfor %}
-                                {% else %}
-                                    {% set val = value.split(':') %}
-                                    {{ key }}: {{ val[0] }}<br />
-                                    <span class="text-muted">&emsp;&emsp;[{{ val[1] }}:{{ val[2] }}]</span><br />
-                                {% endif %}
-                            {% endfor %}
-                        </h5>
-                    </div>
-                </div>
-                <div class="row">
-                    <div class="col">
-                        <h5 class="text-left">
-                            <span class="font-weight-bold">Outputs:</span>
-                            <br/>
-                            {% for key, value in prov.Outputs|items %}
-                                {% if value is iterable and value is not string %}
-                                    {{ key }}: <br />
-                                    {% for sub in value %}
-                                        {% set val = sub.split(':') %}
-                                        &emsp; - {{ val[0] }}<br />
-                                        <span class="text-muted">&emsp;&emsp;[{{ val[1] }}:{{ val[2] }}]</span><br />
-                                    {% endfor %}
-                                {% else %}
-                                    {% set val = value.split(':') %}
-                                    {{ key }}: {{ val[0] }}<br />
-                                    <span class="text-muted">&emsp;&emsp;[{{ val[1] }}:{{ val[2] }}]</span><br />
-                                {% endif %}
-                            {% endfor %}
-                        </h5>
-                    </div>
-                </div>
-                <div class="row">
-                    <div class="col">
-                        <h5 class="text-left">
-                            <span class="font-weight-bold">Parameters:</span>
-                            {% if prov.Parameters is mapping %}
-                                <br/>
-                                {% for key, value in prov.Parameters|items %}
-                                    {% if value is iterable and value is not string %}
-                                        {{ key }}: <br />
-                                        {% for sub in value %}
-                                            &emsp; - {{ sub }}<br />
-                                        {% endfor %}
-                                    {% else %}
-                                        {{ key }}: {{ value }}<br />
-                                    {% endif %}
-                                {% endfor %}
-                            {% else %}
-                                None
-                            {% endif %}
-                        </h5>
-                    </div>
-                </div>
-                <div class="row">
-                        <div class="col">
-                            <h5 class="text-left">
-                                <span class="font-weight-bold">Command:</span>
-                                <br/>
-                                {{ prov.Command }}
-                            </h5>
-                        </div>
-                    </div>
-                </div>
+            <div class="container-fluid">
+                <div class="row"><div class="col text-center">
+                    <button type="button"
+                            data-toggle="modal"
+                            data-target="#prov{{ steploop.index }}{{ provloop.index }}"
+                            class="btn btn-dark">
+                        PROVENANCE
+                    </button>
+                </div></div>
+            </div>
+            <hr />
             <br />
         {% endfor %}
         <br /><br />
@@ -243,8 +172,7 @@
 </nav>
 
 <div class="modal fade" id="imagemodal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
-    <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable" style="max-width: 100%"
-         data-dismiss="modal">
+    <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable" style="max-width: 100%" data-dismiss="modal">
         <div class="modal-content">
             <div class="modal-body">
                 <img src="" class="imagepreview" alt="full size image">
@@ -252,6 +180,130 @@
         </div>
     </div>
 </div>
+
+{% for key, value in processing_results|items %}
+    {% set steploop = loop %}
+        {% for id, prov in value|items %}
+            {% set provloop = loop %}
+            <div class="modal fade" id="prov{{ steploop.index }}{{ provloop.index }}" tabindex="-1" role="dialog" aria-labelledby="prov{{ steploop.index }}-{{ provloop.index }}" aria-hidden="true">
+                <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable" style="max-width: 90%" data-dismiss="modal">
+                    <div class="modal-content">
+                        <div class="modal-body">
+                            <div class="container-fluid" id="prov{{ steploop.index }}-{{ provloop.index }}">
+                                <br/>
+                                <div class="row">
+                                    <div class="col">
+                                        <h6 class="text-center"><span class="font-weight-bold" style="font-size: 120%">ID: </span>{{ prov.Id }}</h6>
+                                    </div>
+                                </div>
+                                <div class="row">
+                                    <div class="col">
+                                        <h6 class="text-left">
+                                            <span class="font-weight-bold" style="font-size: 120%">Container:</span>
+                                            <br/>
+                                            {{ prov.Container.url }}
+                                            <br />
+                                            {{ prov.Container.hash }}
+                                            <br />
+                                            Built: {{ prov.Container.timestamp.strftime('%Y-%m-%d %H:%M:%S') }} by {{ prov.Container.builder }}
+                                        </h6>
+                                    </div>
+                                    <div class="col">
+                                        <h6 class="text-right">
+                                            <span class="font-weight-bold" style="font-size: 120%">Run Info:</span>
+                                            <br/>
+                                            Started: {{ prov.StartTime }}
+                                            <br />
+                                            Duration: {{ prov.Duration }}
+                                            <br />
+                                            User: {{ prov.User }}
+                                        </h6>
+                                    </div>
+                                </div>
+                                <div class="row">
+                                    <div class="col">
+                                        <h6 class="text-left">
+                                            <span class="font-weight-bold" style="font-size: 120%">Inputs:</span>
+                                            <br/>
+                                            {% for key, value in prov.Inputs|items %}
+                                                {% if value is iterable and value is not string %}
+                                                    {{ key }}: <br />
+                                                    {% for sub in value %}
+                                                        {% set val = sub.split(':') %}
+                                                        &emsp; - {{ val[0] }}<br />
+                                                        <span class="text-muted">&emsp;&emsp;[{{ val[1] }}:{{ val[2] }}]</span><br />
+                                                    {% endfor %}
+                                                {% else %}
+                                                    {% set val = value.split(':') %}
+                                                    {{ key }}: <br />
+                                                    &emsp; - {{ val[0] }}<br />
+                                                    <span class="text-muted">&emsp;&emsp;[{{ val[1] }}:{{ val[2] }}]</span><br />
+                                                {% endif %}
+                                            {% endfor %}
+                                        </h6>
+                                    </div>
+                                </div>
+                                <div class="row">
+                                    <div class="col">
+                                        <h6 class="text-left">
+                                            <span class="font-weight-bold" style="font-size: 120%">Outputs:</span>
+                                            <br/>
+                                            {% for key, value in prov.Outputs|items %}
+                                                {% if value is iterable and value is not string %}
+                                                    {{ key }}: <br />
+                                                    {% for sub in value %}
+                                                        {% set val = sub.split(':') %}
+                                                        &emsp; - {{ val[0] }}<br />
+                                                        <span class="text-muted">&emsp;&emsp;[{{ val[1] }}:{{ val[2] }}]</span><br />
+                                                    {% endfor %}
+                                                {% else %}
+                                                    {% set val = value.split(':') %}
+                                                    {{ key }}: <br />
+                                                    &emsp; - {{ val[0] }}<br />
+                                                    <span class="text-muted">&emsp;&emsp;[{{ val[1] }}:{{ val[2] }}]</span><br />
+                                                {% endif %}
+                                            {% endfor %}
+                                        </h6>
+                                    </div>
+                                </div>
+                                <div class="row">
+                                    <div class="col">
+                                        <h6 class="text-left">
+                                            <span class="font-weight-bold" style="font-size: 120%">Parameters:</span>
+                                            {% if prov.Parameters is mapping %}
+                                                <br/>
+                                                {% for key, value in prov.Parameters|items %}
+                                                    {% if value is iterable and value is not string %}
+                                                        {{ key }}: <br />
+                                                        {% for sub in value %}
+                                                            &emsp; - {{ sub }}<br />
+                                                        {% endfor %}
+                                                    {% else %}
+                                                        {{ key }}: {{ value }}<br />
+                                                    {% endif %}
+                                                {% endfor %}
+                                            {% else %}
+                                                None
+                                            {% endif %}
+                                        </h6>
+                                    </div>
+                                </div>
+                                <div class="row">
+                                    <div class="col">
+                                        <h6 class="text-left">
+                                            <span class="font-weight-bold" style="font-size: 120%">Command:</span>
+                                            <br/>
+                                            {{ prov.Command }}
+                                        </h6>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        {% endfor %}
+{% endfor %}
 
 <!-- Optional JavaScript -->
 <!-- jQuery first, then Popper.js, then Bootstrap JS -->
@@ -345,7 +397,6 @@
     $(window).on('load scroll', updateButtonStatus);
 
     function sendPostRequest(btn) {
-        const btn_types = ['ignore', 'change-brain', 'change-cspine', 'change-tspine', 'change-lspine', 'change-orbits'];
         // Retrieve data from the custom data-* attributes of the button
         const api = btn.getAttribute('data-api');
         const loop_idx = btn.getAttribute('data-loop_index');
@@ -354,11 +405,7 @@
             subject: btn.getAttribute('data-subject'),
             session: btn.getAttribute('data-session'),
             source: btn.getAttribute('data-source_path'),
-            body_part: btn.getAttribute('data-body_part'),
-            original_name: btn.getAttribute('data-name')
         };
-        const api_str = (api === 'change') ? `${api}-${data['body_part']}` : api;
-
         // Define the URL to which the POST request will be sent
         const url = window.location.protocol + "//" + window.location.hostname + (window.location.port ? ':' + window.location.port : '') + `/qa/${api}-btn`;
 
@@ -371,14 +418,21 @@
             data: JSON.stringify(data),
             success: function (json) {
                 // Handle a successful response
-                btn_types.forEach(curstr => {
-                    let curr_btn = document.getElementById(`${curstr}${loop_idx}`);
-                    curr_btn.classList.remove("btn-success");
-                    curr_btn.classList.add("btn-dark");
-                });
-                const button = document.getElementById(`${api_str}${loop_idx}`);
+                const fail_btn = document.getElementById(`qa-fail${loop_idx}`);
+                fail_btn.classList.remove("btn-danger");
+                fail_btn.classList.add("btn-dark");
+
+                const pass_btn = document.getElementById(`qa-pass${loop_idx}`);
+                pass_btn.classList.remove("btn-success");
+                pass_btn.classList.add("btn-dark");
+
+                const button = document.getElementById(`${api}${loop_idx}`);
                 button.classList.remove("btn-dark");
-                button.classList.add("btn-success");
+                if (api === 'qa-pass') {
+                    button.classList.add("btn-success");
+                } else {
+                    button.classList.add("btn-danger");
+                }
             },
             error: function (xhr, status, error) {
                 // Handle any errors
@@ -386,47 +440,6 @@
             }
         });
     }
-
-    $(function () {
-        $('#exampleModal').on('show.bs.modal', function (event) {
-            const button = $(event.relatedTarget) // Button that triggered the modal
-            const name = button.data('name') // Extract info from data-* attributes
-            const project = button.data('project')
-            const subject = button.data('subject')
-            const session = button.data('session')
-            const source_path = button.data('source_path')
-            const name_array = name.split('-')
-            // If necessary, you could initiate an AJAX request here (and then do the updating in a callback).
-            // Update the modal's content. We'll use jQuery here, but you could use a data binding library or other methods instead.
-            const modal = $(this)
-            modal.find('.modal-title').text('Correct Naming -- ' + subject + ' / ' + session)
-            modal.find('.modal-body #original-name').val(name)
-            modal.find('.modal-body #project-id').val(project)
-            modal.find('.modal-body #subject-id').val(subject)
-            modal.find('.modal-body #session-id').val(session)
-            modal.find('.modal-body #source-path').val(source_path)
-            modal.find('.modal-body #body-part').val(name_array[0])
-            modal.find('.modal-body #modality').val(name_array[1])
-            modal.find('.modal-body #technique').val(name_array[2])
-            modal.find('.modal-body #acq-dim').val(name_array[3])
-            modal.find('.modal-body #orient').val(name_array[4])
-            modal.find('.modal-body #ex-contrast').val(name_array[5])
-        });
-    });
-    $(function () {
-        $('#note-form-submit').click(function (e) {
-            e.preventDefault();
-            $.post(window.location.protocol + "//" + window.location.hostname + (window.location.port ? ':' + window.location.port : '') + `/qa/manual-entry`, $('#note-form').serialize())
-            $('#exampleModal').modal('hide');
-        });
-    });
-    $(function () {
-        $('#ignore-button-submit').click(function (e) {
-            e.preventDefault();
-            $.post(window.location.protocol + "//" + window.location.hostname + (window.location.port ? ':' + window.location.port : '') + `/qa/ignore-entry`, $('#note-form').serialize())
-            $('#exampleModal').modal('hide');
-        });
-    });
 </script>
 </body>
 </html>

--- a/radifox/records/processing.py
+++ b/radifox/records/processing.py
@@ -45,7 +45,7 @@ class ProcessingModule(ABC):
             if not self.check_outputs():
                 logging.error(f"Processing failed. No outputs reported.")
                 return
-            logging.info(f"Generating QA imagees.")
+            logging.info(f"Generating QA images.")
             self.generate_qa_images()
             logging.info(f"Generating provenance records.")
             self.generate_prov()


### PR DESCRIPTION
Adds buttons to the QA page for processed images that allows a simple pass/fail marker that is logged to a file. QA site now requires a user as well as a key, but this can be any string (no database) and is only used for logging who is performing a QA task.